### PR TITLE
homelab-home: link to blog drafts

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -38,6 +38,7 @@
       <div class="sub">Local service dashboard</div>
     </div>
     <div class="row">
+      <a class="pill" href="https://danmaps.github.io/drafts.html" target="_blank" rel="noreferrer">Blog drafts</a>
       <a class="pill" href="/onboarding.html">Onboarding</a>
     </div>
   </div>


### PR DESCRIPTION
Adds a pill link on the homelab-home header to Danny's blog drafts page.